### PR TITLE
chore(charts): Update Fluent Bit to pull image from MCR

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -69,9 +69,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
       {{- if .Values.OpenServiceMesh.enableFluentbit }}
-        - name: {{ .Values.OpenServiceMesh.fluentBitImage.name }}
-          image: {{ .Values.OpenServiceMesh.fluentBitImage.registry }}/fluent-bit:{{ .Values.OpenServiceMesh.fluentBitImage.tag }}
-          imagePullPolicy: {{ .Values.OpenServiceMesh.fluentBitImage.pullPolicy }}
+        - name: {{ .Values.OpenServiceMesh.fluentBit.name }}
+          image: {{ .Values.OpenServiceMesh.fluentBit.image }}:{{ .Values.OpenServiceMesh.fluentBit.tag }}
+          imagePullPolicy: {{ .Values.OpenServiceMesh.fluentBit.pullPolicy }}
           volumeMounts:
           - name: config
             mountPath: /fluent-bit/etc

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -15,10 +15,10 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: true
   enableEgress: false
   enableFluentbit: true
-  fluentBitImage: # TODO: Update to MCR image
+  fluentBit:
     name: fluentbit-logger
-    registry: fluent
-    tag: 1.5
+    image: "mcr.microsoft.com/oss/fluent/fluent-bit"
+    tag: "v1.6.2"
     pullPolicy: IfNotPresent
   meshName: osm
   useHTTPSIngress: false


### PR DESCRIPTION
Changes Fluent Bit container image to pull v1.6.2 from MCR rather than 1.5 Docker