### PR TITLE
Hide output revealing az account and registry information from user

### DIFF
--- a/.pipelines/e2e-aks-arc.yaml
+++ b/.pipelines/e2e-aks-arc.yaml
@@ -19,4 +19,3 @@ jobs:
         KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
     - template: templates/acr-cleanup.yaml
     - template: templates/aks-cleanup.yaml
-

--- a/.pipelines/templates/acr-cleanup.yaml
+++ b/.pipelines/templates/acr-cleanup.yaml
@@ -3,10 +3,12 @@ steps:
       if [[ -n "${CHECKOUT_TAG}" ]]; then
         az login --identity > /dev/null 2>&1
         echo ${CHECKOUT_TAG}
-        az acr repository delete -n $(registry.name) --image oss/openservicemesh/osm-chart:${CHECKOUT_TAG} --yes > /dev/null 2>&1
+        az acr repository delete -n $(REGISTRY_NAME) --image oss/openservicemesh/osm-chart:${CHECKOUT_TAG} --yes > /dev/null 2>&1
       else
         echo "Helm chart was not published to staging ACR because $CHECKOUT_TAG was not set by the pipeline" && exit 1
       fi
     displayName: Delete helm chart from staging registry
     workingDirectory: $(repo.path)
     condition: always()
+    env: 
+      REGISTRY_NAME: $(REGISTRY_NAME)

--- a/.pipelines/templates/acr-cleanup.yaml
+++ b/.pipelines/templates/acr-cleanup.yaml
@@ -1,9 +1,9 @@
 steps:
   - bash: |
       if [[ -n "${CHECKOUT_TAG}" ]]; then
-        az login --identity
+        az login --identity > /dev/null 2>&1
         echo ${CHECKOUT_TAG}
-        az acr repository delete -n $(registry.name) --image oss/openservicemesh/osm-chart:${CHECKOUT_TAG} --yes
+        az acr repository delete -n $(registry.name) --image oss/openservicemesh/osm-chart:${CHECKOUT_TAG} --yes > /dev/null 2>&1
       else
         echo "Helm chart was not published to staging ACR because $CHECKOUT_TAG was not set by the pipeline" && exit 1
       fi

--- a/.pipelines/templates/aks-cleanup.yaml
+++ b/.pipelines/templates/aks-cleanup.yaml
@@ -1,6 +1,6 @@
 steps:
   - script: |
-      az login --identity
-      az group delete -n ${AZURE_CLUSTER_NAME} --yes --no-wait
+      az login --identity > /dev/null 2>&1
+      az group delete -n ${AZURE_CLUSTER_NAME} --yes --no-wait > /dev/null 2>&1
     displayName: Delete cluster and resource group
     condition: always()

--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -4,15 +4,16 @@ steps:
       echo ${AZURE_CLUSTER_NAME}
     displayName: Create azure cluster name variable
   - script: |
-      az login --identity
+      az login --identity > /dev/null 2>&1
 
-      az group create -n ${AZURE_CLUSTER_NAME} -l ${AZURE_LOCATION}
+      az group create -n ${AZURE_CLUSTER_NAME} -l ${AZURE_LOCATION} > /dev/null 2>&1
 
       az aks create \
           -g ${AZURE_CLUSTER_NAME} \
           -n ${AZURE_CLUSTER_NAME} \
           --enable-managed-identity \
-          --no-ssh-key
+          --no-ssh-key \
+          > /dev/null 2>&1
 
       az aks get-credentials -n ${AZURE_CLUSTER_NAME} -g ${AZURE_CLUSTER_NAME} -f $(System.DefaultWorkingDirectory)/kubeconfig.json
 

--- a/.pipelines/templates/publish-helm-chart.yaml
+++ b/.pipelines/templates/publish-helm-chart.yaml
@@ -9,7 +9,7 @@ steps:
       if [[ -n "${CHECKOUT_TAG}" ]]; then
         cp $(image.dir)/$(chart.name)-${CHECKOUT_TAG}.tgz .
         echo 'pushing chart'
-        oras push $(STAGING_REGISTRY):${CHECKOUT_TAG} ./$(chart.name)-${CHECKOUT_TAG}.tgz:application/tar+gzip --debug
+        oras push $(REPOSITORY_NAME):${CHECKOUT_TAG} ./$(chart.name)-${CHECKOUT_TAG}.tgz:application/tar+gzip --debug
       else 
         echo "Helm chart was not published to staging ACR because $CHECKOUT_TAG was not set by the pipeline" && exit 1
       fi
@@ -17,7 +17,7 @@ steps:
     workingDirectory: $(repo.path)
     env:
       HELM_EXPERIMENTAL_OCI: 1
-      STAGING_REGISTRY: $(STAGING_REGISTRY)
+      REPOSITORY_NAME: $(REPOSITORY_NAME)
   - task: PublishBuildArtifacts@1
     displayName: Publish artifacts
     inputs:

--- a/.pipelines/templates/publish-helm-chart.yaml
+++ b/.pipelines/templates/publish-helm-chart.yaml
@@ -1,13 +1,15 @@
 steps: 
   - bash: |
-      az login --identity
-      az acr login --name $(registry.name)
+      az login --identity > /dev/null 2>&1
+      az acr login --name $(REGISTRY_NAME) > /dev/null 2>&1
     displayName: Login to acr
+    env: 
+      REGISTRY_NAME: $(REGISTRY_NAME)
   - bash: |
       if [[ -n "${CHECKOUT_TAG}" ]]; then
         cp $(image.dir)/$(chart.name)-${CHECKOUT_TAG}.tgz .
         echo 'pushing chart'
-        oras push $(staging.registry):${CHECKOUT_TAG} ./$(chart.name)-${CHECKOUT_TAG}.tgz:application/tar+gzip --debug
+        oras push $(STAGING_REGISTRY):${CHECKOUT_TAG} ./$(chart.name)-${CHECKOUT_TAG}.tgz:application/tar+gzip --debug
       else 
         echo "Helm chart was not published to staging ACR because $CHECKOUT_TAG was not set by the pipeline" && exit 1
       fi
@@ -15,6 +17,7 @@ steps:
     workingDirectory: $(repo.path)
     env:
       HELM_EXPERIMENTAL_OCI: 1
+      STAGING_REGISTRY: $(STAGING_REGISTRY)
   - task: PublishBuildArtifacts@1
     displayName: Publish artifacts
     inputs:

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ package-osm-chart:
 	
 e2e-bootstrap:
 	# Download and install kind
-	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
+	#curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
 	# Download and install kubectl
-	curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
+	#curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
 	# Download and install bats
 	sudo apt-get -o Acquire::Retries=30 update && sudo apt-get -o Acquire::Retries=30 install -y bats
 	# Check for existing kind cluster

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ package-osm-chart:
 	
 e2e-bootstrap:
 	# Download and install kind
-	#curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
+	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
 	# Download and install kubectl
-	#curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
+	curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
 	# Download and install bats
 	sudo apt-get -o Acquire::Retries=30 update && sudo apt-get -o Acquire::Retries=30 install -y bats
 	# Check for existing kind cluster

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -6,6 +6,8 @@ RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-arc-osm-system}"
 export RESOURCEID=subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME
 export HELM_EXPERIMENTAL_OCI=1
 
+echo $RESOURCEID
+
 jq -n \
     --arg tag "$CHECKOUT_TAG" \
     --arg namespace "$RELEASE_NAMESPACE" \

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -13,7 +13,7 @@ jq -n \
     --arg namespace "$RELEASE_NAMESPACE" \
     '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } } } }' > osm_extension.json
 
-az account set --subscription=$SUBSCRIPTION
+az account set --subscription=$SUBSCRIPTION > /dev/null 2>&1
 
 az extension remove --name connectedk8s
 
@@ -22,12 +22,12 @@ az extension add --source https://shasbextensions.blob.core.windows.net/extensio
 az -v 
 
 # enable connected cluster
-az connectedK8s connect -n  $CLUSTERNAME -g $RESOURCEGROUP -l $REGION
+az connectedK8s connect -n  $CLUSTERNAME -g $RESOURCEGROUP -l $REGION > /dev/null 2>&1
 
 # confirm
 helm ls --all --all-namespaces
 
-az resource tag --tags logAnalyticsWorkspaceResourceId=/$RESOURCEID --ids /$RESOURCEID
+az resource tag --tags logAnalyticsWorkspaceResourceId=/$RESOURCEID --ids /$RESOURCEID > /dev/null 2>&1
 
 # get extensions enabled on this cluster
 az rest --method GET --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions?api-Version=2020-07-01-preview"


### PR DESCRIPTION
Redirect bash output to /dev/null for steps in CI pipeline that reveal sensitive information such as tenantID and staging registry. Most of this can be hidden by setting the variable types to "secrets" in the ADO UI, but some steps (such as the ACR cleanup) still leak information we want to keep hidden. Setting variables to "secret" also require you to explicitly list them as env variables in the scripts you use them in, so I also needed to add that as well. 