### PR TITLE
parameterized test.bats

### DIFF
--- a/.pipelines/e2e-aks-arc.yaml
+++ b/.pipelines/e2e-aks-arc.yaml
@@ -17,5 +17,6 @@ jobs:
       env: 
         CHECKOUT_TAG: $(CHECKOUT_TAG)
         KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
+        ARC_CLUSTER: true
     - template: templates/acr-cleanup.yaml
     - template: templates/aks-cleanup.yaml


### PR DESCRIPTION
Only arc-specific tests only run if we are testing on arc cluster with osm chart pushed to staging ACR, as opposed to a kind cluster with osm chart installed direcly. 