### PR TITLE
feat(chart): add proxy config override template

### DIFF
--- a/charts/osm-arc/templates/proxy-config-override.yaml
+++ b/charts/osm-arc/templates/proxy-config-override.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.azureHTTPProxy .Values.azureHTTPSProxy }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxy-config
+stringData:
+  HTTP_PROXY: {{ .Values.azureHTTPProxy | quote }}
+  HTTPS_PROXY: {{ .Values.azureHTTPSProxy | quote }}
+{{- end }}

--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+azureHTTPProxy:
+azureHTTPSProxy:
+
 OpenServiceMesh:
     ignoreNamespaces: "kube-system azure-arc arc-osm-system"
 


### PR DESCRIPTION
This adds a template for proxy-config Secret which is meant
to replace the proxy-config secret in the osm subchart. Because
the default value of .Values.fluentBit.enableProxySupport in the
osm subchart is false AND we do not change this value as part of the
parent chart, we can create a new proxy-config Secret in the parent
chart if the azureHTTPProxy and azureHTTPSProxy values are passed in
at install time.

To test these changes, run:
```$ helm template charts/osm-arc > output1.yaml```
In output1.yaml, you should not find a Secret called proxy-config. Neither chart created a Secret called proxy-config.

To see the proxy-config Secret, run:
```$ helm template charts/osm-arc --set "azureHTTPProxy=something1,azureHTTPSProxy=something2" > output2.yaml```
In output2.yaml, you should see a Secret called proxy-config. This was created by the parent chart because the two values related to proxy settings were passed in.

Note: these are not the final value names. Once those are finalized by the azure arc extension team, we can update them and the configuration in this chart.

Signed-off-by: Michelle Noorali <minooral@microsoft.com>