### PR TITLE
tests: fix logic for parameterized tests

### DIFF
--- a/.pipelines/e2e-aks-arc.yaml
+++ b/.pipelines/e2e-aks-arc.yaml
@@ -17,6 +17,5 @@ jobs:
       env: 
         CHECKOUT_TAG: $(CHECKOUT_TAG)
         KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
-        ARC_CLUSTER: true
     - template: templates/acr-cleanup.yaml
     - template: templates/aks-cleanup.yaml

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -6,7 +6,7 @@ WAIT_TIME=120
 SLEEP_TIME=1
 WAIT_TIME_DEPLOYMENTS=600
 SLEEP_TIME_DEPLOYMENTS=10
-ARC_CLUSTER=${ARC_CLUSTER:-false}
+ARC_CLUSTER=${ARC_CLUSTER:-true}
 
 @test "arc-osm-system deployments have succeeded" {
     run wait_for_process $WAIT_TIME_DEPLOYMENTS $SLEEP_TIME_DEPLOYMENTS "kubectl wait --for=condition=available deployment --all --namespace arc-osm-system"


### PR DESCRIPTION
Fixes failing logic for arc-cluster-specific tests by moving conditionals within test blocks. Flips boolean to default to expect an arc cluster. Skipped tests will now show up as:
```
ok 8 azure-arc deployments have succeeded # skip arc cluster-specific test
ok 9 chart version on cluster matches checkout tag # skip arc cluster-specific test
ok 10 openservicemesh.io/ignore is true in azure-arc # skip arc cluster-specific test
```