### PR TITLE
Removed ConnectVault variable

### DIFF
--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -23,7 +23,6 @@ osm:
     deployJaeger: false
     webhookConfigNamePrefix: arc-osm-webhook
     sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.15.0
-    connectVault: false
   
 alpine:
   image:


### PR DESCRIPTION
Removed connectVault from values.yaml as this variable is no longer used in Upstream chart. 