### PR TITLE
Makefile: Add shellcheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BATS_VERSION ?= 1.2.1
 
 package-osm-chart:
 	helm dependency update osm-arc
-	
+
 install-prerequisites:
 	# Setup kind if TEST_KIND is set to true
 	if [ $(TEST_KIND) ]; then make setup-kind ; fi
@@ -41,3 +41,8 @@ e2e-cleanup:
 	helm uninstall osm -n arc-osm-system
 	kubectl delete namespace arc-osm-system
 	if [ $(TEST_KIND) ]; then kind delete cluster; fi
+
+# Install shellcheck with: "sudo apt install shellcheck"
+.PHONY: shellcheck
+shellcheck:
+	shellcheck -x $(shell find . -name '*.sh')


### PR DESCRIPTION
Given that we have a non-trivial amount of bash scripts here - it would be good to add `shellcheck`, which will point out issues and how to fix these.

This can be run with `make shellcheck` and will give hints on fixing common Bash issues.

Next step: fix bash issues `shellcheck` discovers.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>