### PR TITLE
Double quoting Bash variables to prevent globbing and word splitting

### DIFF
--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source .env
+
 RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-arc-osm-system}"
 EXTENSION_NAME="${EXTENSION_NAME:-osm}"
 API_VERSION="${API_VERSION:-2020-07-01-preview}"
@@ -8,7 +9,7 @@ EXTENSION_SETTINGS=$1
 
 export RESOURCEID=subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME
 
-echo $RESOURCEID
+echo "Azure Resource ID: $RESOURCEID"
 
 if [[ -z "$EXTENSION_SETTINGS" ]]; then
     EXTENSION_SETTINGS="osm_extension.json"
@@ -18,15 +19,23 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
         '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } } } }' > osm_extension.json
 fi
 
-az account set --subscription=$SUBSCRIPTION > /dev/null 2>&1
+az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
 # confirm
 helm ls --all --all-namespaces
 
-az resource tag --tags logAnalyticsWorkspaceResourceId=/$RESOURCEID --ids /$RESOURCEID > /dev/null 2>&1
+az resource tag \
+   --tags logAnalyticsWorkspaceResourceId="/$RESOURCEID" \
+   --ids "/$RESOURCEID" > /dev/null 2>&1
 
 # get extensions enabled on this cluster
-az rest --method GET --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions?api-Version=$API_VERSION"
+az rest \
+   --method GET \
+   --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions?api-Version=$API_VERSION"
 
 # enable the osm extension
-az rest --method PUT --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" --body @$EXTENSION_SETTINGS --debug
+az rest \
+   --method PUT \
+   --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" \
+   --body @$EXTENSION_SETTINGS \
+   --debug

--- a/scripts/connect-to-arc.sh
+++ b/scripts/connect-to-arc.sh
@@ -2,12 +2,13 @@
 
 CONNECTEDK8S_VERSION="${CONNECTEDK8S_VERSION:-0.3.5}"
 
-az account set --subscription=$SUBSCRIPTION > /dev/null 2>&1
+az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
 az extension remove --name connectedk8s
 
-az extension add --source $AZ_EXTENSION_LOCATION/connectedk8s-$CONNECTEDK8S_VERSION-py2.py3-none-any.whl -y
+az extension add --source "$AZ_EXTENSION_LOCATION/connectedk8s-$CONNECTEDK8S_VERSION-py2.py3-none-any.whl" -y
 
 az -v
+
 # enable connected cluster
-az connectedk8s connect -n  $CLUSTERNAME -g $RESOURCEGROUP -l $REGION > /dev/null 2>&1
+az connectedk8s connect -n  "$CLUSTERNAME" -g "$RESOURCEGROUP" -l "$REGION" > /dev/null 2>&1

--- a/scripts/delete-extension.sh
+++ b/scripts/delete-extension.sh
@@ -2,11 +2,14 @@
 
 source .env
 
-export RESOURCEID=subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME
+export RESOURCEID="subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME"
 EXTENSION_NAME="${EXTENSION_NAME:-osm}"
 API_VERSION="${API_VERSION:-2020-07-01-preview}"
 
-az account set --subscription=$SUBSCRIPTION
+az account set --subscription="$SUBSCRIPTION"
 
 # disable the osm extension
-az rest --method DELETE --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" --debug
+az rest \
+   --method DELETE \
+   --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" \
+   --debug

--- a/scripts/enable-arc-feature.sh
+++ b/scripts/enable-arc-feature.sh
@@ -4,7 +4,7 @@ source .env
 
 # enable Arc feature for subscription
 
-az account set --subscription=$SUBSCRIPTION
+az account set --subscription="$SUBSCRIPTION"
 
 az feature register --namespace Microsoft.Kubernetes --name previewAccess
 

--- a/scripts/publish-chart.sh
+++ b/scripts/publish-chart.sh
@@ -4,9 +4,19 @@ source .env
 
 export HELM_EXPERIMENTAL_OCI=1
 
-az account set --subscription=$SUBSCRIPTION
+az account set --subscription="$SUBSCRIPTION"
 
-./helm package --version $IMAGETAG --destination $IMAGEDIR $REPO --debug
-oras push $REGISTRY/$CHARTNAME:$IMAGETAG ./$CHARTNAME-$IMAGETAG.tgz:application/tar+gzip --debug
+./helm package \
+       --version "$IMAGETAG" \
+       --destination "$IMAGEDIR" \
+       "$REPO" \
+       --debug
 
-az acr repository show-manifests --name $REGISTRY --repository $REPO
+oras push \
+     "$REGISTRY/$CHARTNAME:$IMAGETAG" \
+     "./$CHARTNAME-$IMAGETAG.tgz:application/tar+gzip" \
+     --debug
+
+az acr repository show-manifests \
+   --name "$REGISTRY" \
+   --repository "$REPO"

--- a/scripts/update-extension.sh
+++ b/scripts/update-extension.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 source .env
+
 RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-arc-osm-system}"
 EXTENSION_NAME="${EXTENSION_NAME:-osm}"
 API_VERSION="${API_VERSION:-2020-07-01-preview}"
 EXTENSION_SETTINGS=$1
 
-export RESOURCEID=subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME
+export RESOURCEID="subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCEGROUP/providers/Microsoft.Kubernetes/connectedClusters/$CLUSTERNAME"
 
-echo $RESOURCEID
+echo "Azure Resource ID: $RESOURCEID"
 
 if [[ -z "$EXTENSION_SETTINGS" ]]; then
     EXTENSION_SETTINGS="osm_extension.json"
@@ -18,7 +19,11 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
         '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } } } }' > osm_extension.json
 fi
 
-az account set --subscription=$SUBSCRIPTION > /dev/null 2>&1
+az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
-# enable the osm extension
-az rest --method PUT --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" --body @$EXTENSION_SETTINGS --debug
+# enable the OSM Extension
+az rest \
+   --method PUT \
+   --uri "https://management.azure.com/$RESOURCEID/providers/Microsoft.KubernetesConfiguration/extensions/$EXTENSION_NAME?api-Version=$API_VERSION" \
+   --body @$EXTENSION_SETTINGS \
+   --debug


### PR DESCRIPTION
This PR leverages [shellcheck](https://www.shellcheck.net/) introduced with https://github.com/Azure/osm-azure/pull/66 and addresses some of the suggestions `make shellcheck` produces.

In this PR:
  - Double quoting Bash variables to prevent globbing and word splitting
  - Split long bash statements into multiple lines
  - Augmenting some of the `echo` statements with additional context

No functional code changes.