### PR TITLE
chore(logs): use and override controllerLogLevel instead of fluentBit.logLevel

### DIFF
--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -18,6 +18,7 @@ osm:
       outputPlugin: azure
       workspaceId: 65b3ea97-f79d-4607-b3c8-6bc9543b5607
       primaryKey: 1EijNEurquqoILM02FxTUp5BmX55SyV+NkL6hhAFllv3DEb8b8cYPoh49gSmRo4qJrirAhYEptqnyyfDvsfl0Q==
+    controllerLogLevel: error
     enforceSingleMesh: true
     enablePrometheus: false
     deployJaeger: false

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -16,7 +16,7 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
     jq -n \
         --arg tag "$CHECKOUT_TAG" \
         --arg namespace "$RELEASE_NAMESPACE" \
-        '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } }, "configurationProtectedSettings": { "osm.OpenServiceMesh.fluentBit.logLevel": "debug", } } }' > osm_extension.json
+        '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } }, "configurationProtectedSettings": { "osm.OpenServiceMesh.controllerLogLevel": "debug", } } }' > osm_extension.json
 fi
 
 az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1

--- a/scripts/update-extension.sh
+++ b/scripts/update-extension.sh
@@ -16,7 +16,7 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
     jq -n \
         --arg tag "$CHECKOUT_TAG" \
         --arg namespace "$RELEASE_NAMESPACE" \
-        '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } }, "configurationProtectedSettings": { "osm.OpenServiceMesh.fluentBit.logLevel": "debug", } } }' > osm_extension.json
+        '{properties: {extensionType: "Microsoft.openservicemesh", autoUpgradeMinorVersion: "false", version: $tag, releaseTrain: "Staging", scope: { cluster: { releaseNamespace: $namespace } }, "configurationProtectedSettings": { "osm.OpenServiceMesh.controllerLogLevel": "debug", } } }' > osm_extension.json
 fi
 
 az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1


### PR DESCRIPTION
Context: A `controllerLogLevel` variable was added upstream that controls which level of logs are emitted by the controller. This takes away the need for Fluent Bit to filter on log level. [This PR](https://github.com/openservicemesh/osm/pull/2726) in OSM removes Fluent Bit logLevel variable and filters in favor of the controllerLogLevel variable. In upstream, the controller log level is set to "info".

This PR overrides controller log level to "error" to match the previous behavior of `fluentBit.logLevel`.

Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>