### PR TITLE
Make k8s.version configurable

### DIFF
--- a/.pipelines/aks-addon-nightly/e2e-aks-addon-jobs.yaml
+++ b/.pipelines/aks-addon-nightly/e2e-aks-addon-jobs.yaml
@@ -7,6 +7,8 @@ jobs:
     - template: ../templates/install-helm3.yaml
     - template: ../templates/checkout-upstream-repo.yaml
     - template: ../templates/aks-setup.yaml
+      parameters:
+        aksAddonRun: true
     - template: ../templates/aks-addon-templates/enable-osm-aks-addon.yaml
     - template: ../templates/run-upstream-e2e.yaml
       parameters:

--- a/.pipelines/templates/aks-setup.yaml
+++ b/.pipelines/templates/aks-setup.yaml
@@ -1,3 +1,8 @@
+parameters: 
+  - name: aksAddonRun
+    type: boolean
+    default: false
+
 steps:
   - script: |
       echo "##vso[task.setvariable variable=AZURE_CLUSTER_NAME]osm-helm-e2e-$(openssl rand -hex 6)"
@@ -8,12 +13,22 @@ steps:
 
       az group create -n ${AZURE_CLUSTER_NAME} -l ${AKS_CLUSTER_LOCATION} > /dev/null 2>&1
 
-      az aks create \
-          -g ${AZURE_CLUSTER_NAME} \
-          -n ${AZURE_CLUSTER_NAME} \
-          --enable-managed-identity \
-          --no-ssh-key \
-          > /dev/null 2>&1
+      if [[ "${{ parameters.aksAddonRun }}" == "True" ]]; then
+        az aks create \
+            -g ${AZURE_CLUSTER_NAME} \
+            -n ${AZURE_CLUSTER_NAME} \
+            --enable-managed-identity \
+            --no-ssh-key \
+            --kubernetes-version ${K8S_VERSION} \
+            > /dev/null 2>&1
+      else
+        az aks create \
+            -g ${AZURE_CLUSTER_NAME} \
+            -n ${AZURE_CLUSTER_NAME} \
+            --enable-managed-identity \
+            --no-ssh-key \
+            > /dev/null 2>&1
+      fi
 
       az aks get-credentials -n ${AZURE_CLUSTER_NAME} -g ${AZURE_CLUSTER_NAME} -f $(System.DefaultWorkingDirectory)/kubeconfig.json
 


### PR DESCRIPTION
This is needed for the AKS addon nightly job, as AKS add-on releases are now synced with specific minimum k8s version cutoffs.