### PR TITLE
Fix chart version

### DIFF
--- a/.pipelines/e2e-aks-arc.yaml
+++ b/.pipelines/e2e-aks-arc.yaml
@@ -16,7 +16,7 @@ jobs:
         make test-e2e
       displayName: "Run osm-azure e2e tests"
       env: 
-        CHECKOUT_TAG: $(CHECKOUT_TAG)
+        EXTENSION_TAG: $(CHART_TAG)
         KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
     - template: templates/run-upstream-e2e.yaml
     - template: templates/debug-resources.yaml

--- a/.pipelines/e2e-job.yaml
+++ b/.pipelines/e2e-job.yaml
@@ -17,7 +17,6 @@ variables:
   image.dir: $(Build.ArtifactStagingDirectory)
   image.artifact.name: drop
   KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
-  image.tag: 0.1.0
   upstream.repo: https://github.com/openservicemesh/osm
 
 stages: 

--- a/.pipelines/templates/package-helm-chart.yaml
+++ b/.pipelines/templates/package-helm-chart.yaml
@@ -1,13 +1,5 @@
 steps: 
-- script: |
-    echo "##vso[task.setvariable variable=UNIQUE_TAG]$(git rev-parse --short HEAD)"
-    echo ${UNIQUE_TAG}
-  displayName: Create Unique Tag
-- script: |
-    echo "##vso[task.setvariable variable=CHECKOUT_TAG]$(image.tag)-${UNIQUE_TAG}"
-    echo ${CHECKOUT_TAG}
-  displayName: Create Checkout Tag 
-- bash: | 
-    helm dependency update $(chart.path)
-    helm package --version ${CHECKOUT_TAG} --destination $(image.dir) $(chart.path) --debug
-  displayName: Package the helm chart
+  - bash: | 
+      helm dependency update $(chart.path)
+      helm package --destination $(image.dir) $(chart.path) --debug
+    displayName: Package the helm chart

--- a/.pipelines/templates/publish-helm-chart.yaml
+++ b/.pipelines/templates/publish-helm-chart.yaml
@@ -1,3 +1,8 @@
+parameters: 
+  - name: releaseTag
+    type: boolean
+    default: false
+
 steps: 
   - bash: |
       az login --identity > /dev/null 2>&1
@@ -5,11 +10,32 @@ steps:
     displayName: Login to acr
     env: 
       REGISTRY_NAME: $(REGISTRY_NAME)
+  - script: |
+      cp $(image.dir)/$(chart.name)-*.tgz .
+      FILENAME=$(ls $(chart.name)-*.tgz)
+      TRIM=${FILENAME##$(chart.name)-}
+      echo "##vso[task.setvariable variable=CHART_TAG]${TRIM%%.tgz}"
+      echo ${CHART_TAG}
+    displayName: Get osm-arc chart version
+  - script: |
+      echo "##vso[task.setvariable variable=UNIQUE_TAG]$(git rev-parse --short HEAD)"
+      echo ${UNIQUE_TAG}
+    displayName: Create Unique Tag
+  - script: |
+      echo ${{ parameters.releaseTag }}
+      if [[ "${{ parameters.releaseTag }}" == "True" ]]; then
+        # Add "-release" for chart created by release job.  
+        echo "##vso[task.setvariable variable=CHECKOUT_TAG]${CHART_TAG}-${UNIQUE_TAG}-release"
+      else
+        # Add "-pr" for chart created by pr job.  
+        echo "##vso[task.setvariable variable=CHECKOUT_TAG]${CHART_TAG}-${UNIQUE_TAG}-pr"
+      fi
+      echo ${CHECKOUT_TAG}
+    displayName: Create Checkout Tag 
   - bash: |
       if [[ -n "${CHECKOUT_TAG}" ]]; then
-        cp $(image.dir)/$(chart.name)-${CHECKOUT_TAG}.tgz .
         echo 'pushing chart'
-        oras push $(REPOSITORY_NAME):${CHECKOUT_TAG} ./$(chart.name)-${CHECKOUT_TAG}.tgz:application/tar+gzip --debug
+        oras push $(REPOSITORY_NAME):${CHECKOUT_TAG} ./$(chart.name)-${CHART_TAG}.tgz:application/tar+gzip --debug
       else 
         echo "Helm chart was not published to staging ACR because $CHECKOUT_TAG was not set by the pipeline" && exit 1
       fi

--- a/.pipelines/templates/publish-helm-chart.yaml
+++ b/.pipelines/templates/publish-helm-chart.yaml
@@ -1,8 +1,3 @@
-parameters: 
-  - name: releaseTag
-    type: boolean
-    default: false
-
 steps: 
   - bash: |
       az login --identity > /dev/null 2>&1
@@ -21,15 +16,8 @@ steps:
       echo "##vso[task.setvariable variable=UNIQUE_TAG]$(git rev-parse --short HEAD)"
       echo ${UNIQUE_TAG}
     displayName: Create Unique Tag
-  - script: |
-      echo ${{ parameters.releaseTag }}
-      if [[ "${{ parameters.releaseTag }}" == "True" ]]; then
-        # Add "-release" for chart created by release job.  
-        echo "##vso[task.setvariable variable=CHECKOUT_TAG]${CHART_TAG}-${UNIQUE_TAG}-release"
-      else
-        # Add "-pr" for chart created by pr job.  
-        echo "##vso[task.setvariable variable=CHECKOUT_TAG]${CHART_TAG}-${UNIQUE_TAG}-pr"
-      fi
+  - script: | 
+      echo "##vso[task.setvariable variable=CHECKOUT_TAG]${CHART_TAG}-${UNIQUE_TAG}-pr"
       echo ${CHECKOUT_TAG}
     displayName: Create Checkout Tag 
   - bash: |

--- a/.pipelines/templates/run-upstream-e2e.yaml
+++ b/.pipelines/templates/run-upstream-e2e.yaml
@@ -2,7 +2,7 @@ steps:
   - bash: |
       git clone -b v${CHART_TAG} $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
       kubectl get pods -A
-    displayName: Checkout $(upstream.repo) @ ${UPSTREAM_BRANCH}
+    displayName: Checkout $(upstream.repo) @ ${CHART_TAG}
   - bash: |
       make build-osm 
       go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -test.timeout 60m -installType=NoInstall -OsmNamespace=arc-osm-system

--- a/.pipelines/templates/run-upstream-e2e.yaml
+++ b/.pipelines/templates/run-upstream-e2e.yaml
@@ -1,6 +1,6 @@
 steps: 
   - bash: |
-      git clone -b ${UPSTREAM_BRANCH} $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
+      git clone -b v${CHART_TAG} $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
       kubectl get pods -A
     displayName: Checkout $(upstream.repo) @ ${UPSTREAM_BRANCH}
   - bash: |

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -51,11 +51,11 @@ ARC_CLUSTER=${ARC_CLUSTER:-true}
     assert_success
 }
 
-@test "chart version on cluster matches checkout tag" {
+@test "chart version on cluster matches extension tag" {
     if [ $ARC_CLUSTER == false ]; then
         skip "arc cluster-specific test"
     fi
-    [[ "$(helm ls -o json --namespace arc-osm-system | jq -r '.[].chart')" == "osm-arc-$CHECKOUT_TAG" ]]
+    [[ "$(helm ls -o json --namespace arc-osm-system | jq -r '.[].chart')" == "osm-arc-$EXTENSION_TAG" ]]
 }
 
 @test "openservicemesh.io/ignore is true in azure-arc" { 


### PR DESCRIPTION
This PR uses the current chart version instead of hardcoding the image.tag as 0.1.0. This current chart version is also used to checkout the appropriate upstream branch instead of checking out the branch corresponding to the current version in main. 