### PR TITLE
chore(github): add PR templates for default and release PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -1,0 +1,20 @@
+This PR requires approval from 3 maintainers.
+
+<!--
+
+Use the checklist below to ensure your release PR is complete before marking it ready for review.
+
+-->
+
+- [] I have ensured that required images are available in MCR:
+	1. osm-controller, osm-injector and init images of the corresponding chart version
+	2. fluent-bit and envoy images of versions listed in osm-arc/oss values.yaml
+
+- [ ] I have updated the Helm chart:
+    1. Updated the chart version, app version and dependency version in charts/osm-arc/Chart.yaml    
+    2. Made applicable updates to the osm-arc values.yaml if any were made in the upstream OSM chart
+    
+    <!--
+    In upstream, compare between the latest release and the previous release to check if anything has changed in the OSS values.yaml e.g: https://github.com/openservicemesh/osm/compare/v0.6.1...v0.7.0-rc.1
+    Check for variable name changes, removed variables, variables that need to be overridden, etc. and make applicable changes in the osm-arc chart.    
+    -->   

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+
+Please describe the motivation for this PR and provide enough
+information so that others can review it.
+
+-->
+**Description**:
+
+<!--
+
+Please mark with X for applicable areas.
+
+-->
+**Affected area**:
+
+- New Functionality      [ ]
+- Documentation          [ ]
+- Install                [ ]
+- Networking             [ ]
+- Metrics                [ ]
+- Security               [ ]
+- Tests                  [ ]
+- CI System              [ ]
+- Performance            [ ]
+- Other                  [ ]
+
+
+Please answer the following questions with yes/no.
+
+- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?


### PR DESCRIPTION
* Default PR template similar to OSS PR template, auto populates when you open a PR
* Release PR template can be used by adding `?expand=1&template=release_pull_request_template.md` to the PR URL during creation or copying the raw template