### PR TITLE
feat(openshift): Remove osm-label securityContext

### DIFF
--- a/charts/osm-arc/templates/osm-label.yml
+++ b/charts/osm-arc/templates/osm-label.yml
@@ -88,14 +88,11 @@ metadata:
     "helm.sh/hook-weight": "35"
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    seccomp.security.alpha.kubernetes.io/pod: runtime/default
 spec:
   template:
     metadata:
       labels:
         app: osm-label
-      annotations:
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
     spec:
       serviceAccountName: osm-label-account
       automountServiceAccountToken: true
@@ -168,10 +165,3 @@ spec:
               else
                 echo "Failed to retrieve ${osmnamespace} details"
               fi  
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
-        supplementalGroups: [5555]
-
-


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This PR removes annotations and securityContexts that are incompatible with default OpenShift clusters SCC. They will be reintroduced when extension metadata can be propagated to the helm chart so that we can add these fields conditionally.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No