### PR TITLE
feat(chart): add pod label

### DIFF
--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -21,7 +21,15 @@ osm:
     deployJaeger: false
     webhookConfigNamePrefix: arc-osm-webhook
     sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.17.2
-  
+    osmcontroller:
+      podLabels: {
+        app.kubernetes.io/component: osm-controller
+      }
+    injector:
+      podLabels: {
+        app.kubernetes.io/component: osm-controller
+      }
+
 alpine:
   image:
     name: "mcr.microsoft.com/azure-policy/alpine"


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This PR adds `app.kubernetes.io/component: osm-controller` labels to osm pods so we can use them to scrape osm metrics. 
NOTE: This PR depends on upstream release of v0.8.3-rc.1 
Pending #87 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [X]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No