### PR TITLE
docs: refactor the Getting Started doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
+#!make
+
 KIND_VERSION ?= 0.8.1
+
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= v1.19.0
 BATS_VERSION ?= 1.2.1

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -9,7 +9,7 @@ Use the following scripts to publish chart, enable connected cluster, and add OS
 
 > Note: Get latest wheels: https://github.com/Azure/azure-arc-kubernetes-preview/tree/master/extensions
 
-1. Install the latest [connectedk8s](https://docs.microsoft.com/en-us/cli/azure/connectedk8s?view=azure-cli-latest).
+1. Install the latest [connectedk8s](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster).
 ```bash
 WHEEL="<location of the Azure CLI Python wheel file>"
 az extension add --source $WHEEL --yes || true

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -81,8 +81,7 @@ az k8s-extension create \
   --release-train=staging \
   --name=osm \
   --release-namespace=arc-osm-system \
-  --version=0.8.2 \
-  --subscription=<Azure-subscription>
+  --version=0.8.2
 ```
 
 
@@ -94,7 +93,6 @@ az k8s-extension delete \
   --resource-group=<Azure-resource-group> \
   --cluster-type=connectedClusters \
   --name=osm \
-  --subscription=<Azure-subscription> \
   --yes || true
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,4 +1,4 @@
-# Get Started with Open Service Mesh Arc extension
+# Get Started with Open Service Mesh Arc Add-on
 Use the following scripts to publish chart, enable connected cluster, and add OSM Arc extension.
 
 ## Prerequisites

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -42,12 +42,6 @@ az feature register \
 ```
 
 ```bash
-az feature register \
-  --namespace Microsoft.KubernetesConfiguration \
-  --name extensions
-```
-
-```bash
 az provider register \
   --namespace Microsoft.ExtendedLocation
 ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -31,12 +31,6 @@ az account set --subscription=<your-Azure-subscription-ID>
 
 ```bash
 az feature register \
-  --namespace Microsoft.Kubernetes \
-  --name previewAccess
-```
-
-```bash
-az feature register \
   --namespace Microsoft.KubernetesConfiguration \
   --name sourceControlConfiguration
 ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,5 +1,5 @@
 # Get Started with Open Service Mesh Arc Add-on
-Use the following scripts to publish chart, enable connected cluster, and add OSM Arc extension.
+Use the following scripts to publish chart, enable connected cluster, and add OSM Arc add-on.
 
 ## Prerequisites
 - Running Kubernetes cluster

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,11 +1,113 @@
-## Get Started
+# Get Started with Open Service Mesh Arc extension
 Use the following scripts to publish chart, enable connected cluster, and add OSM Arc extension.
 
 ## Prerequisites
 - Running Kubernetes cluster
-- Azure CLI
+- [Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 
-### Set env vars
+## Add Azure CLI extensions
+
+> Note: Get latest wheels: https://github.com/Azure/azure-arc-kubernetes-preview/tree/master/extensions
+
+1. Install the latest [connectedk8s](https://docs.microsoft.com/en-us/cli/azure/connectedk8s?view=azure-cli-latest).
+```bash
+WHEEL="<location of the Azure CLI Python wheel file>"
+az extension add --source $WHEEL --yes || true
+```
+
+2. Install the latest [k8s-extension](https://docs.microsoft.com/en-us/cli/azure/k8s-extension?view=azure-cli-latest).
+```bash
+WHEEL="<location of the Azure CLI Python wheel file>"
+az extension add --source $WHEEL --yes || true
+```
+
+## Enable Arc Features
+The following steps need to be run only once for a given subscription:
+
+_Optional_: set default Azure subscription for the `az` CLI:
+```bash
+az account set --subscription=<your-Azure-subscription-ID>
+```
+
+```bash
+az feature register \
+  --namespace Microsoft.Kubernetes \
+  --name previewAccess
+```
+
+```bash
+az feature register \
+  --namespace Microsoft.KubernetesConfiguration \
+  --name sourceControlConfiguration
+```
+
+```bash
+az feature register \
+  --namespace Microsoft.KubernetesConfiguration \
+  --name extensions
+```
+
+```bash
+az provider register \
+  --namespace Microsoft.ExtendedLocation
+```
+
+```bash
+az feature register \
+  --namespace Microsoft.ExtendedLocation \
+  --name CustomLocations-ppauto
+```
+
+## Connect Cluster and Install Arc Extension
+
+Install the Arc agent and connect the Kubernetes cluster to Azure:
+> Note: `--location` must be one of `eastus`, `eastus2euap`, or `westeurope` (as of 2021-04-20).
+
+```bash
+az connectedk8s connect \
+  --name=<Azure-name-of-the-Arc-connector> \
+  --resource-group=<Azure-resource-group> \
+  --location eastus
+```
+
+Install Open Service Mesh Arc extension:
+```bash
+az k8s-extension create \
+  --cluster-name=<Azure-name-of-the-Arc-connector> \
+  --resource-group=<Azure-resource-group> \
+  --cluster-type=connectedClusters \
+  --extension-type=Microsoft.openservicemesh \
+  --scope=cluster \
+  --release-train=staging \
+  --name=osm \
+  --release-namespace=arc-osm-system \
+  --version=0.8.2 \
+  --subscription=<Azure-subscription>
+```
+
+
+## Clean-up
+1. Remove the Open Service Mesh Arc extension
+```bash
+az k8s-extension delete \
+  --cluster-name=<Azure-name-of-the-Arc-connector> \
+  --resource-group=<Azure-resource-group> \
+  --cluster-type=connectedClusters \
+  --name=osm \
+  --subscription=<Azure-subscription> \
+  --yes || true
+```
+
+2. Disconnect Kubernetes cluster from Azure and remove Arc agent:
+```bash
+az connectedk8s delete \
+  --name=<Azure-name-of-the-Arc-connector> \
+  --resource-group=<Azure-resource-group> || true
+```
+
+
+### Publish Chart to Azure Container Registry
+
 The OSM Azure repo relies on environment variables to make it usable on your localhost. The root of the repository contains a file named `.env.example`. Copy the contents of this file into `.env`
 ```bash
 cat .env.example > .env
@@ -15,28 +117,7 @@ The various environment variables are documented in the `.env.example` file itse
 Note: Ensure the region specified in the .env file has the latest OSM arc extension available. Supported regions listed [here](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/connect-cluster#supported-regions).
 
 
-### Enable Arc Features
-This step needs to be run only once for every new subscription.
-```sh
-./scripts/enable-arc-feature.sh
-```
-
-### Add Arc Extension to Cluster
-This step needs to be run for each Kubernetes cluster that needs the Arc OSM extension. It will add the connectedk8s extension to the Azure CLI, enable arc on the Kubernetes cluster (installs arc agents and components), and install the osm arc extension on the Kubernetes cluster.
-```sh
-./scripts/add-extension.sh
-```
-
-### Remove Arc Extension from Cluster
-This step needs to be run for each cluster when you want to remove the OSM Arc extension. Note that this script does not remove Arc connectivity.
-
-This script also does not delete the `arc-osm-system` and `azure-arc` namespaces.
-```sh
-./scripts/delete-extension.sh
-```
-
-### Publish Chart to Azure Container Registry
 This step only needs to be run when publishing a new OSM Arc Helm chart.
-```sh
+```bash
 ./scripts/publish-chart.sh
 ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -16,6 +16,7 @@ az extension add --source $WHEEL --yes || true
 ```
 
 2. Install the latest [k8s-extension](https://docs.microsoft.com/en-us/cli/azure/k8s-extension?view=azure-cli-latest).
+Download the lastest [wheel file](https://github.com/Azure/azure-arc-kubernetes-preview/blob/master/extensions/k8s_extension_private-0.2.1b2-py3-none-any.whl).
 ```bash
 WHEEL="<location of the Azure CLI Python wheel file>"
 az extension add --source $WHEEL --yes || true

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -7,16 +7,15 @@ Use the following scripts to publish chart, enable connected cluster, and add OS
 
 ## Add Azure CLI extensions
 
-> Note: Get latest wheels: https://github.com/Azure/azure-arc-kubernetes-preview/tree/master/extensions
-
 1. Install the latest [connectedk8s](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/quickstart-connect-cluster).
+> Download the latest [wheel file](https://github.com/Azure/azure-arc-kubernetes-preview/blob/master/extensions/connectedk8s-0.3.8-py2.py3-none-any.whl).
 ```bash
 WHEEL="<location of the Azure CLI Python wheel file>"
 az extension add --source $WHEEL --yes || true
 ```
 
 2. Install the latest [k8s-extension](https://docs.microsoft.com/en-us/cli/azure/k8s-extension?view=azure-cli-latest).
-Download the lastest [wheel file](https://github.com/Azure/azure-arc-kubernetes-preview/blob/master/extensions/k8s_extension_private-0.2.1b2-py3-none-any.whl).
+> Download the lastest [wheel file](https://github.com/Azure/azure-arc-kubernetes-preview/blob/master/extensions/k8s_extension_private-0.2.1b2-py3-none-any.whl).
 ```bash
 WHEEL="<location of the Azure CLI Python wheel file>"
 az extension add --source $WHEEL --yes || true


### PR DESCRIPTION
This PR peels-off the bash scripts from the Getting Started doc to use the underlying `az` CLI commands instead.