### PR TITLE
fix logic for prev tag for upgrade job

### DIFF
--- a/.pipelines/templates/get-latest-tag.yaml
+++ b/.pipelines/templates/get-latest-tag.yaml
@@ -2,15 +2,9 @@ steps:
   - bash: |
       tags=$(git tag | tr - \~ | sort -V | tr \~ - | sed "/^$tag$/q")
       tags=$(grep -Eve '-(alpha|beta|rc)' <<< "$tags")
-
-      if [[ "$tag" =~ -(alpha|beta|rc) ]]; then
-        prev=$(tail -1 <<< "$tags" | head -1)
-      else
-        prev=$(tail -2 <<< "$tags" | head -1)
-      fi
-      
+      prev=$(tail -1 <<< "$tags" | head -1)
       echo "##vso[task.setvariable variable=LATEST_PUBLISHED_TAG]${prev:1}"
       echo ${LATEST_PUBLISHED_TAG}
-    displayName: Get most recent osm-arc tag
+    displayName: Get most recent published osm-arc tag
     env: 
       tag: $(CHART_VERSION)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: This PR fixes a bug where the upgrade-e2e job fetches the 2nd most recent stable release, instead of the most recent stable release, for non-rc tags. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [X]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?