### PR TITLE
Add field for validated distros in values.yaml

### DIFF
--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -9,6 +9,7 @@ Azure:
 
 OpenServiceMesh:
     ignoreNamespaces: "kube-system azure-arc arc-osm-system"
+    testedDistros: "aks gke eks openshift rancher_rke"
 
 osm:
   OpenServiceMesh:


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add field in the values.yaml called "testedDistros," which az k8s-extension will fetch to notify the user whether their current k8s distros has been tested for osm-arc. https://github.com/Azure/azure-cli-extensions/pull/3336. Note that az connectedk8s doesn't validate whether the current distro is canonical yet. The list of all the return values for kubernetes_distro can be found here: https://github.com/Azure/azure-cli-extensions/blob/0bf8ef35e22d520708dc3fc99179f3f2e1a87332/src/connectedk8s/azext_connectedk8s/custom.py#L436

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?