### PR TITLE
Set nodeselector to linux

### DIFF
--- a/charts/osm-arc/templates/osm-label.yml
+++ b/charts/osm-arc/templates/osm-label.yml
@@ -115,6 +115,8 @@ spec:
       automountServiceAccountToken: true
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
         - name: osm-label
           image: {{ .Values.alpine.image.name }}:{{ .Values.alpine.image.tag }}

--- a/charts/osm-arc/templates/osm-label.yml
+++ b/charts/osm-arc/templates/osm-label.yml
@@ -116,7 +116,8 @@ spec:
       restartPolicy: Never
       terminationGracePeriodSeconds: 0
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: osm-label
           image: {{ .Values.alpine.image.name }}:{{ .Values.alpine.image.tag }}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Set the nodeselector to Linux for the osm-label job. Without this, osm-arc will not install successfully on AKS-HCI clusters, as the job will try to run on a windows container and fail. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?