### PR TITLE
Fix crd upgrade step

### DIFF
--- a/.pipelines/templates/checkout-upstream-repo.yaml
+++ b/.pipelines/templates/checkout-upstream-repo.yaml
@@ -1,4 +1,4 @@
 steps:
   - bash: |
       git clone $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
-    displayName: Checkout $(upstream.repo) @ v${CHART_VERSION}
+    displayName: Checkout $(upstream.repo)

--- a/.pipelines/templates/checkout-upstream-repo.yaml
+++ b/.pipelines/templates/checkout-upstream-repo.yaml
@@ -1,4 +1,4 @@
 steps:
   - bash: |
-      git clone -b v${CHART_VERSION} $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
+      git clone $(upstream.repo) $(System.DefaultWorkingDirectory)/osm
     displayName: Checkout $(upstream.repo) @ v${CHART_VERSION}

--- a/.pipelines/templates/run-upstream-e2e.yaml
+++ b/.pipelines/templates/run-upstream-e2e.yaml
@@ -3,6 +3,7 @@ steps:
       sleep 180
     displayName: "Add delay before running upstream e2es"
   - bash: |
+      git checkout v$(CHART_VERSION)
       make build-osm
       go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -test.timeout 60m -installType=NoInstall -OsmNamespace=$(release.namespace)
     displayName: "Run upstream e2e tests"

--- a/.pipelines/templates/upgrade-CRDS.yaml
+++ b/.pipelines/templates/upgrade-CRDS.yaml
@@ -2,7 +2,7 @@ steps:
   - bash: |
       git checkout v$(CHART_VERSION)
       crd_changes=$(git diff --name-only "v${LATEST_PUBLISHED_TAG}".."v${CHART_VERSION}" -- charts/osm/crds)
-      echo "##vso[task.setvariable variable=CRD_CHANGES]$crd_changes
+      echo "##vso[task.setvariable variable=CRD_CHANGES]$crd_changes"
     displayName: Verify if CRD changes are necessary
     workingDirectory: $(System.DefaultWorkingDirectory)/osm
   - bash: |

--- a/.pipelines/templates/upgrade-CRDS.yaml
+++ b/.pipelines/templates/upgrade-CRDS.yaml
@@ -1,11 +1,23 @@
 steps:
   - bash: |
+      git checkout v$(CHART_VERSION)
       crd_changes=$(git diff --name-only "v${LATEST_PUBLISHED_TAG}".."v${CHART_VERSION}" -- charts/osm/crds)
-      if ! [[ -z "$crd_changes" ]]; then
+      echo "##vso[task.setvariable variable=CRD_CHANGES]$crd_changes
+    displayName: Verify if CRD changes are necessary
+    workingDirectory: $(System.DefaultWorkingDirectory)/osm
+  - bash: |
+      git checkout v$(LATEST_PUBLISHED_TAG)
+      if ! [[ -z "$(CRD_CHANGES)" ]]; then
         echo "Deleting CRDs"
         ./scripts/cleanup/crd-cleanup.sh
+      fi
+    displayName: Delete old CRDS if necessary
+    workingDirectory: $(System.DefaultWorkingDirectory)/osm
+  - bash: |
+      git checkout v$(CHART_VERSION)
+      if ! [[ -z "$(CRD_CHANGES)" ]]; then
         echo "Installing new CRDs"
         kubectl apply -f charts/osm/crds
       fi
-    displayName: Delete old CRDS and install new ones if necessary
+    displayName: Install new CRDS if necessary
     workingDirectory: $(System.DefaultWorkingDirectory)/osm

--- a/.pipelines/upgrade-e2e-job.yaml
+++ b/.pipelines/upgrade-e2e-job.yaml
@@ -10,9 +10,9 @@ pr:
   branches:
     include:
     - main
-  paths:
-    include:
-      - charts/osm-arc/Chart.yaml
+  #paths:
+    #include:
+      #- charts/osm-arc/Chart.yaml
 
 variables:
   chart.name: osm-arc


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: The CRD upgrade step for the upgrade-e2e-job was running the CRD cleanup script from the current upstream branch, instead of the upstream branch corresponding to the previous release which was installed prior to the upgrade. This fix ensures that the CRDs are deleted from the "previous" branch, and the installed from the "current" branch. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?