### PR TITLE
Change upstream e2e branch

### DIFF
--- a/.pipelines/aks-addon-nightly/e2e-aks-addon-jobs.yaml
+++ b/.pipelines/aks-addon-nightly/e2e-aks-addon-jobs.yaml
@@ -8,5 +8,7 @@ jobs:
     - template: ../templates/aks-setup.yaml
     - template: ../templates/aks-addon-templates/enable-osm-aks-addon.yaml
     - template: ../templates/run-upstream-e2e.yaml
+      parameters:
+        aksAddonRun: true
     - template: ../templates/debug-resources.yaml
     - template: ../templates/aks-cleanup.yaml

--- a/.pipelines/templates/run-upstream-e2e.yaml
+++ b/.pipelines/templates/run-upstream-e2e.yaml
@@ -1,9 +1,20 @@
+parameters: 
+  - name: aksAddonRun
+    type: boolean
+    default: false
+
 steps:
   - bash: |
       sleep 180
     displayName: "Add delay before running upstream e2es"
   - bash: |
-      git checkout v$(CHART_VERSION)
+      if [[ "${{ parameters.aksAddonRun }}" == "True" ]]; then
+        git checkout ${UPSTREAM_E2E_BRANCH}
+      else
+        trimmed_tag=$(echo $(CHART_VERSION) | cut -d'-' -f 1)
+        release_branch=release-v$(echo $trimmed_tag | cut -d'.' -f -2)
+        git checkout $release_branch
+      fi
       make build-osm
       go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -test.timeout 60m -installType=NoInstall -OsmNamespace=$(release.namespace)
     displayName: "Run upstream e2e tests"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Changed the branch that the upstream e2es are run from, so that they are run from release branches instead of checking out tags. Note that the logic for determining which branch to run works slightly differently for AKS add-on vs the osm-arc PR gate. OSM-Arc cannot use a UI variable for the release branch, because PRs that update the chart to different versions (ex from v0.8.4 to v0.9.0) will need to run on a different branch than all the other PRs currently in progress with v0.8.4. The AKS addon job can use a UI variable because it doesn't need to worry about version differences between PRs. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?