### PR TITLE
Add job to test osm-arc in prod

### DIFF
--- a/.pipelines/osm-arc-prod.yaml
+++ b/.pipelines/osm-arc-prod.yaml
@@ -1,0 +1,19 @@
+jobs: 
+  - job: test_osm_arc_prod
+    pool: staging-pool
+    workspace: 
+      clean: all
+    steps:
+    - template: templates/aks-setup.yaml
+    - template: templates/enable-arc.yaml
+    - template: templates/add-arc-extension.yaml
+      parameters: 
+        imageTag: $(EXTENSION_VERSION)
+        releaseTrain: $(EXTENSION_RELEASE_TRAIN)
+    - script: |
+        make test-e2e
+      displayName: "Run osm-azure e2e tests"
+      env: 
+        EXTENSION_TAG: $(EXTENSION_VERSION)
+      KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
+    - template: templates/aks-cleanup.yaml

--- a/.pipelines/templates/add-arc-extension.yaml
+++ b/.pipelines/templates/add-arc-extension.yaml
@@ -2,6 +2,9 @@ parameters:
   - name: imageTag
     type: string
     default: $(IMAGE_TAG)
+  - name: releaseTrain
+    type: string
+    default: "staging"
 
 steps:
   - bash: |
@@ -22,3 +25,4 @@ steps:
       EXTENSION_TAG: ${{ parameters.imageTag }}
       REGION: $(AZURE_LOCATION)
       RELEASE_NAMESPACE: $(release.namespace)
+      RELEASE_TRAIN: ${{ parameters.releaseTrain }}

--- a/.pipelines/test-osm-arc-prod.yaml
+++ b/.pipelines/test-osm-arc-prod.yaml
@@ -1,0 +1,9 @@
+trigger: none
+
+variables:
+  KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
+
+stages: 
+- stage: run_e2e
+  jobs:
+    - template: osm-arc-prod.yaml

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -5,6 +5,8 @@ source .env
 RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-arc-osm-system}"
 EXTENSION_NAME="${EXTENSION_NAME:-osm}"
 EXTENSION_SETTINGS=$1
+RELEASE_TRAIN="${RELEASE_TRAIN:-staging}"
+
 
 az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
@@ -18,7 +20,7 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
       --cluster-type connectedClusters \
       --extension-type Microsoft.openservicemesh \
       --scope cluster \
-      --release-train staging \
+      --release-train $RELEASE_TRAIN \
       --name $EXTENSION_NAME \
       --release-namespace $RELEASE_NAMESPACE \
       --version $EXTENSION_TAG
@@ -29,7 +31,7 @@ else
       --cluster-type connectedClusters \
       --extension-type Microsoft.openservicemesh \
       --scope cluster \
-      --release-train staging \
+      --release-train $RELEASE_TRAIN \
       --name $EXTENSION_NAME \
       --release-namespace $RELEASE_NAMESPACE \
       --version $EXTENSION_TAG \

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -7,7 +7,6 @@ EXTENSION_NAME="${EXTENSION_NAME:-osm}"
 EXTENSION_SETTINGS=$1
 RELEASE_TRAIN="${RELEASE_TRAIN:-staging}"
 
-
 az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
 # confirm


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add a new, manually triggered pipeline to test osm-arc in prod. Extension version and release train will be passed in as UI configurable variables. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No