### PR TITLE
Fix libgmp10 security vulnerability in helm cli image

### DIFF
--- a/tools/helm/Dockerfile
+++ b/tools/helm/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETOS
 ENV helm_version 3.7.1
 
 # upgrading libssl1.1, libgssapi-krb5-2, libk5crypto3 libkrb5-3, and libkrb5support0 due to CVE-2021-37750
-RUN clean-install jq curl ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0
+RUN clean-install jq curl ca-certificates libssl1.1 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libgmp10
 
 RUN curl https://get.helm.sh/helm-v${helm_version}-${TARGETOS}-${TARGETARCH}.tar.gz -o helm.tar.gz && \
     tar -xvf helm.tar.gz && \


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Install the most up to date libgmp10 version in the helm cli image to address security vulnerability CVE-2021-43618, which is causing the nightly image scan job to fail. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?