### PR TITLE
Add register-extension script and call in CI

### DIFF
--- a/.pipelines/pr-job/e2e-aks-arc.yaml
+++ b/.pipelines/pr-job/e2e-aks-arc.yaml
@@ -16,6 +16,7 @@ jobs:
     - template: ../templates/publish-helm-chart.yaml
       parameters:
         releaseTag: ${{ parameters.releaseE2E }}
+    - template: ../templates/register-extension.yaml
     - template: ../templates/checkout-upstream-repo.yaml
     - template: ../templates/aks-setup.yaml
     - template: ../templates/enable-arc.yaml

--- a/.pipelines/templates/publish-helm-chart.yaml
+++ b/.pipelines/templates/publish-helm-chart.yaml
@@ -35,7 +35,8 @@ steps:
   - bash: |
       if [[ -n "${IMAGE_TAG}" ]]; then
         echo 'pushing chart'
-        oras push $(REPOSITORY_NAME):${IMAGE_TAG} ./$(chart.name)-${CHART_VERSION}.tgz:application/tar+gzip --debug
+        mv $(chart.name)-${CHART_VERSION}.tgz $(chart.name)-${IMAGE_TAG}.tgz
+        oras push $(REPOSITORY_NAME):${IMAGE_TAG} ./$(chart.name)-${IMAGE_TAG}.tgz:application/tar+gzip --debug
       else 
         echo "Helm chart was not published to staging ACR because $IMAGE_TAG was not set by the pipeline" && exit 1
       fi
@@ -43,6 +44,9 @@ steps:
     env:
       HELM_EXPERIMENTAL_OCI: 1
       REPOSITORY_NAME: $(REPOSITORY_NAME)
+  - task: ManifestGeneratorTask@0
+    inputs:
+      BuildDropPath: $(image.dir)
   - task: PublishBuildArtifacts@1
     displayName: Publish artifacts
     inputs:

--- a/.pipelines/templates/register-extension.yaml
+++ b/.pipelines/templates/register-extension.yaml
@@ -1,0 +1,19 @@
+steps:
+  - bash: |
+      ARC_ACCESS_TOKEN=$(az account get-access-token --resource $(ARC_RESOURCE_TOKEN) | jq -r '.accessToken')
+      echo "##vso[task.setvariable variable=ARC_ACCESS_TOKEN]$ARC_ACCESS_TOKEN"
+    displayName: Get Arc Access Token
+    env:
+      ARC_RESOURCE_TOKEN: $(ARC_RESOURCE_TOKEN)
+  - bash: |
+      ./scripts/register-extension.sh
+    displayName: Register Arc Extension
+    env:
+      REGISTRY_PATH: $(REPOSITORY_NAME)
+      SUBSCRIPTION: $(SUBSCRIPTION_ID)
+      ACCESS_TOKEN: $(ARC_ACCESS_TOKEN)
+      ARC_API_URL: $(ARC_API_URL)
+      VERSION: $(IMAGE_TAG)
+  - bash: |
+      rm request.json
+    displayName: Cleanup request json

--- a/scripts/register-extension.sh
+++ b/scripts/register-extension.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Register osm-arc extension with Arc Registration API
+
+REGION=${REGION:-'"eastus2euap", "eastus", "westeurope"'}
+RELEASE_TRAINS="${RELEASE_TRAINS:-staging}"
+PACKAGE_CONFIG_NAME="${PACKAGE_CONFIG_NAME:-microsoft.openservicemesh20220214}"
+API_VERSION="${API_VERSION:-2021-05-01}"
+METHOD="${METHOD:-put}"
+
+# Create JSON request body
+cat <<EOF > "request.json"
+{
+  "artifactEndpoints": [
+    {
+      "Regions": [
+          $REGION
+      ],
+      "Releasetrains": [
+          "$RELEASE_TRAINS"
+      ],
+      "FullPathToHelmChart": "$REGISTRY_PATH",
+      "ExtensionUpdateFrequencyInMinutes": 60,
+      "IsCustomerHidden": false,
+      "ReadyforRollout": true,
+      "RollbackVersion": null,
+      "PackageConfigName": "$PACKAGE_CONFIG_NAME"
+    }
+  ]
+}
+EOF
+
+# Send Request
+az rest --method $METHOD --headers "{\"Authorization\": \"Bearer $ACCESS_TOKEN\", \"Content-Type\": \"application/json\"}" --body @request.json --uri $ARC_API_URL/subscriptions/$SUBSCRIPTION/extensionTypeRegistrations/microsoft.openservicemesh/versions/$VERSION?api-version=$API_VERSION


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add register-extension script and add to CI to register Arc extension for the chart that's pushed to staging. This registers the extension by generating an access token and making an `AZ REST` PUT request to the Arc registration API.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?