### PR TITLE
metrics: add metrics agent to send metrics via telegraf

### DIFF
--- a/charts/osm-arc/templates/_helpers.tpl
+++ b/charts/osm-arc/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/* Labels to be added to all resources */}}
+{{- define "osm.arcLabels" -}}
+app.kubernetes.io/name: openservicemesh.io
+app.kubernetes.io/instance: {{ .Values.osm.osm.meshName }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}

--- a/charts/osm-arc/templates/azure-extension-identity.yaml
+++ b/charts/osm-arc/templates/azure-extension-identity.yaml
@@ -1,0 +1,10 @@
+apiVersion: clusterconfig.azure.com/v1beta1
+kind: AzureExtensionIdentity
+metadata:
+  name: osm
+  namespace: azure-arc
+spec:
+  serviceAccounts:
+    - name: {{ .Release.Name }}
+      namespace: {{ .Release.Namespace }}
+  tokenNamespace: {{ .Release.Namespace }}

--- a/charts/osm-arc/templates/metrics-agent-deployment.yaml
+++ b/charts/osm-arc/templates/metrics-agent-deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osm-metrics-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: osm-metrics-agent
+    {{- include "osm.arcLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: osm-metrics-agent
+  template:
+    metadata:
+      labels:
+        app: osm-metrics-agent
+        {{- include "osm.arcLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: mdm
+          image: linuxgeneva-microsoft.azurecr.io/genevamdm:master_20220401.1
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: ROLEINSTANCE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CONFIG_OVERRIDES_FILE
+              value: /tmp/geneva_mdm/mdmconfig.json
+            - name: MDM_INPUT
+              value: statsd_udp,statsd_tcp
+            - name: MDM_LOG_LEVEL
+              value: "Info"
+          volumeMounts:
+            - name: mdm-config
+              mountPath: /tmp/geneva_mdm
+        - name: msi-adapter
+          image: mcr.microsoft.com/azurearck8s/msi-adapter:1.0.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TOKEN_NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: EXTENSION_ARMID
+              value: {{ .Values.Azure.Extension.ResourceId }}
+            - name: EXTENSION_NAME
+              value: {{ .Values.Azure.Extension.Name }}
+            - name: CLUSTER_TYPE
+              value: ConnectedClusters
+            - name: CLUSTER_IDENTITY
+              value: "false"
+            - name: MANAGED_IDENTITY_AUTH
+              value: "true"
+            - name: TEST_MODE
+              value: "false"
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+        - name: prom-mdm-converter
+          image: upstreamarc.azurecr.io/prom-mdm-converter:v1.0.0
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: SERVER_PORT
+              value: "8090"
+            - name: GENEVA_DEFAULT_MDM_NAMESPACE
+              value: {{ .Values.Azure.Cluster.Region }}
+            - name: GENEVA_ACCOUNT_NAME
+              value: AzureServiceMesh
+            - name: EXTENSION_RESOURCE_ID
+              value: {{ .Values.Azure.Extension.ResourceId }}
+        - name: telegraf
+          image: mcr.microsoft.com/oss/mirror/docker.io/library/telegraf:1.21
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          volumeMounts:
+            - name: telegraf-conf
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+      volumes:
+        - name: mdm-config
+          configMap:
+            name: osm-mdm-config
+        - name: telegraf-conf
+          configMap:
+            name: osm-telegraf-config

--- a/charts/osm-arc/templates/metrics-config.yaml
+++ b/charts/osm-arc/templates/metrics-config.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osm-mdm-config
+  namespace: {{ .Release.Namespace }}
+data:
+  mdmconfig.json: "{\"imdsInfo\":[{ \"account\": \"AzureServiceMesh\" }]}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osm-telegraf-config
+  namespace: {{ .Release.Namespace }}
+data:
+  telegraf.conf: |-
+    [agent]
+      interval = "60s"
+      flush_interval = "10s"
+      metric_batch_size = 250
+      metric_buffer_limit = 1000
+
+    [[inputs.prometheus]]
+      monitor_kubernetes_pods = true
+      kubernetes_label_selector = "app.kubernetes.io/component=osm-controller"
+      monitor_kubernetes_pods_namespace = "{{ .Release.Namespace }}"
+      bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      namedrop = ["rest_client_requests_*", "rest_client_request_*", "go_memstats_gc_*", "go_memstats_stack_*", "go_threads*", "go_memstats_mcache_*_bytes", "go_memstats_mspan_*_bytes", "go_memstats_last*", "go_memstats_next*", "go_memstats_other*", "go_memstats_sys*", "go_memstats_heap_idle_bytes", "go_memstats_heap_inuse_bytes", "go_memstats_heap_objects", "go_memstats_heap_released_bytes", "go_memstats_heap_sys_bytes", "process_*_fds", "process_threads_*", "process_*_pagefault_*", "process_disk_*", "process_*_context_switches_*", "process_num*", "process_open*", "process_resident*", "process_working*", "dotnet_collection_count_total*", "dotnet_total_memory_bytes", "go_gc_duration_seconds", "go_goroutines", "go_info", "internal_*", "workqueue_*", "kubernetes_node", "version_*"]
+
+    [[inputs.kube_inventory]]
+      url = "https://kubernetes.default.svc"
+      namespace = "{{ .Release.Namespace }}"
+      bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_ca = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      response_timeout = "5s"
+      resource_include = [ "pods" ]
+      fielddrop = ["state_code", "state_reason", "phase_reason", "terminated_reason", "resource_requests_millicpu_units", "resource_requests_memory_bytes", "resource_limits_millicpu_units", "resource_limits_memory_bytes"]
+
+    [[outputs.http]]
+      ## URL is the address to send metrics to
+      url = "http://127.0.0.1:8090/push"
+
+      ## Data format to output.
+      data_format = "prometheusremotewrite"
+
+      [outputs.http.headers]
+        Content-Type = "application/x-protobuf"
+        Content-Encoding = "snappy"
+        X-Prometheus-Remote-Write-Version = "0.1.0"

--- a/charts/osm-arc/templates/metrics-rbac.yaml
+++ b/charts/osm-arc/templates/metrics-rbac.yaml
@@ -1,0 +1,55 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-identity
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osm.arcLabels" . | nindent 4 }}
+rules:
+  - apiGroups: [ 'clusterconfig.azure.com' ]
+    resources: [ 'azureclusteridentityrequests' ]
+    verbs: [ 'get', 'create' ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Release.Name}}-identity
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osm.arcLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osm-identity
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-telegraf
+  labels:
+    {{- include "osm.arcLabels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources:
+    - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-telegraf
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osm.arcLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-telegraf
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -6,6 +6,10 @@
 Azure:
   Cluster:
     Distribution: <cluster_distribution>
+    Region: ""
+  Extension:
+    Name: ""
+    ResourceId: ""
 
 OpenServiceMesh:
   ignoreNamespaces: "kube-system azure-arc arc-osm-system"

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -42,6 +42,26 @@ ARC_CLUSTER=${ARC_CLUSTER:-true}
     assert_success
 }
 
+@test "mdm container has been deployed" {
+    run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl get pods -n arc-osm-system -l app=osm-metrics-agent -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c | grep mdm"
+    assert_success
+}
+
+@test "msi-adapter container has been deployed" {
+    run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl get pods -n arc-osm-system -l app=osm-metrics-agent -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c | grep msi-adapter"
+    assert_success
+}
+
+@test "telegraf container has been deployed" {
+    run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl get pods -n arc-osm-system -l app=osm-metrics-agent -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c | grep telegraf"
+    assert_success
+}
+
+@test "prom-mdm-converter container has been deployed" {
+    run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl get pods -n arc-osm-system -l app=osm-metrics-agent -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c | grep prom-mdm-converter"
+    assert_success
+}
+
 @test "mutating webhook has been deployed" {
     run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io arc-osm-webhook-osm"
     assert_success


### PR DESCRIPTION
Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description:**

* Adds a metric agent pod that helps send metrics to MDM
using Telegraf as a pipeline.
* prom-mdm-converter container helps convert Prometheus
metrics into statsd format for consumption by MDM.

**Testing done:**
- Tested that kube-inventory outputs match resource limits set on pods
- Tested setting metrics namespace as the region of extension installation
- Bats tests added for basic readiness of metrics pods

Follow up: metrics in a proxy environment

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [x]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [x]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?