### PR TITLE
Fix go env conf test image

### DIFF
--- a/conformance/plugins/osm-arc/conformance.yaml
+++ b/conformance/plugins/osm-arc/conformance.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-osm-conformance
   result-format: junit
 spec:
-  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.1.7
+  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.1.8
   imagePullPolicy: Always
   name: plugin
   resources: {}

--- a/conformance/plugins/osm-arc/osm_arc_conformance.sh
+++ b/conformance/plugins/osm-arc/osm_arc_conformance.sh
@@ -132,6 +132,7 @@ cd osm
 export CTR_REGISTRY="openservicemesh"
 export CTR_TAG=v$OSM_ARC_VERSION
 
+go env -w GO111MODULE=on
 make build-osm
 
 if [[ "$KUBERNETES_DISTRIBUTION" == "openshift" ]]; then


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Fix go env variable setting, which was causing the `make build-osm` step to fail in the conformance test plugin. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?