### PR TITLE
Fix conf plugin v1.1.1-1

### DIFF
--- a/conformance/plugins/osm-arc/conformance.yaml
+++ b/conformance/plugins/osm-arc/conformance.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-osm-conformance
   result-format: junit
 spec:
-  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.1.9
+  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.2.0
   imagePullPolicy: Always
   name: plugin
   resources: {}

--- a/conformance/plugins/osm-arc/osm_arc_conformance.sh
+++ b/conformance/plugins/osm-arc/osm_arc_conformance.sh
@@ -130,7 +130,13 @@ git clone -b $OSM_TEST_BRANCH $UPSTREAM_REPO
 cd osm
 
 export CTR_REGISTRY="openservicemesh"
-export CTR_TAG=v$OSM_ARC_VERSION
+
+if [[ "$OSM_ARC_VERSION" == *"-"* && "$OSM_ARC_VERSION" != *"rc"* ]]; then
+  trimmed_tag=$(echo $OSM_ARC_VERSION | cut -d'-' -f 1)
+  export CTR_TAG=v$trimmed_tag
+else
+  export CTR_TAG=v$OSM_ARC_VERSION
+fi
 
 go env -w GO111MODULE=on
 make build-osm


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Fix osm-arc conformance plugin for v1.1.1-1. Previously, the conformance test plugin was not properly handling osm-arc versions with a "-", which caused it to fail some e2es such as the client-server and egress tests, since the CTR_TAG was invalid for the test images used in those e2es. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?