### PR TITLE
Add retry logic to conformance test plugin

### DIFF
--- a/conformance/plugins/osm-arc/conformance.yaml
+++ b/conformance/plugins/osm-arc/conformance.yaml
@@ -3,7 +3,7 @@ sonobuoy-config:
   plugin-name: azure-arc-osm-conformance
   result-format: junit
 spec:
-  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.2.0
+  image: osmazure.azurecr.io/tests/osm-arc-conformance:0.2.1
   imagePullPolicy: Always
   name: plugin
   resources: {}


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Update the conformance test plugin to rerun tests that failed. Retry logic parses and formats XML output accordingly to rerun failed tests. 

Tested locally for both passing and failing scenarios (deliberately triggered failures). 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?