### PR TITLE
Fix ci triggers for release branches

### DIFF
--- a/.pipelines/pr-job/e2e-job.yaml
+++ b/.pipelines/pr-job/e2e-job.yaml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - release-v*
   paths:
     exclude:
       - docs/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
     - main
+    - release-v*
   paths:
     exclude:
       - docs/*

--- a/.pipelines/upgrade-job/upgrade-e2e-job.yaml
+++ b/.pipelines/upgrade-job/upgrade-e2e-job.yaml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
     - main
+    - release-v*
   paths:
     include:
       - charts/osm-arc/Chart.yaml
@@ -12,6 +13,7 @@ pr:
   branches:
     include:
     - main
+    - release-v*
   paths:
     include:
       - charts/osm-arc/Chart.yaml


### PR DESCRIPTION
Signed-off-by: nshankar <nshankar@microsoft.ghe.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Fix CI triggers so that the pr-e2e-arc and upgrade-e2e-arc jobs get triggered for PRs against release branches. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No