### PR TITLE
fix: pin k8s-extension version to 1.3.5

### DIFF
--- a/conformance/plugins/osm-arc/osm_arc_conformance.sh
+++ b/conformance/plugins/osm-arc/osm_arc_conformance.sh
@@ -165,7 +165,7 @@ if [ "${waitSuccessArc}" == false ]; then
     exit 1
 fi
 
-az extension add --name k8s-extension 2> ${results_dir}/error || python3 setup_failure_handler.py
+az extension add --name k8s-extension --version 1.3.5 2> ${results_dir}/error || python3 setup_failure_handler.py
 
 az k8s-extension create \
     --cluster-name $CLUSTER_NAME \

--- a/scripts/install-k8s-extension.sh
+++ b/scripts/install-k8s-extension.sh
@@ -4,6 +4,6 @@ az account set --subscription="$SUBSCRIPTION" > /dev/null 2>&1
 
 az extension remove --name k8s-extension
 
-az extension add --name k8s-extension
+az extension add --name k8s-extension --version 1.3.5
 
 az -v


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The upgrade e2e pipeline is failing due to issues with the k8-extension. Pinning version to v1.3.5

**Passing upgrade-e2e-arc pipeline with change**: https://dev.azure.com/AzureContainerUpstream/OpenServiceMesh/_build/results?buildId=77849&view=logs&j=9de9e2b7-8af7-5276-a88f-b4157127a375&t=113d0cda-a20a-5c06-6ada-e4487e3a394d
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [x]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No