### PR TITLE
Arc release v1.2.6 stable

### DIFF
--- a/.pipelines/upgrade-job/upgrade-templates.yaml
+++ b/.pipelines/upgrade-job/upgrade-templates.yaml
@@ -2,11 +2,11 @@ steps:
   - template: ../templates/get-latest-tag.yaml
   - template: ../templates/add-arc-extension.yaml
     parameters: 
-      imageTag: v1.2.3 # Temporarily hard-coding
+      imageTag: 1.2.3 # Temporarily hard-coding
   - script: |
       make test-e2e
     displayName: "Run osm-azure e2e tests on latest release chart"
     env: 
-      EXTENSION_TAG: v1.2.3 # Temporarily hard-coding
+      EXTENSION_TAG: 1.2.3 # Temporarily hard-coding
       KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
   - template: ../templates/update-arc-addon.yaml

--- a/.pipelines/upgrade-job/upgrade-templates.yaml
+++ b/.pipelines/upgrade-job/upgrade-templates.yaml
@@ -2,11 +2,11 @@ steps:
   - template: ../templates/get-latest-tag.yaml
   - template: ../templates/add-arc-extension.yaml
     parameters: 
-      imageTag: $(LATEST_PUBLISHED_TAG)
+      imageTag: v1.2.3 # Temporarily hard-coding
   - script: |
       make test-e2e
     displayName: "Run osm-azure e2e tests on latest release chart"
     env: 
-      EXTENSION_TAG: $(LATEST_PUBLISHED_TAG)
+      EXTENSION_TAG: v1.2.3 # Temporarily hard-coding
       KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
   - template: ../templates/update-arc-addon.yaml

--- a/charts/osm-arc/Chart.yaml
+++ b/charts/osm-arc/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6-beta-1
+version: 1.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.2.6-beta-1
+appVersion: v1.2.6
 
 dependencies:
 - name: osm


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Update charts to v1.2.6 stable. 

- [x] I have ensured that required images are available in MCR:
	1. osm-controller, osm-injector, osm-bootstrap, osm-crds and init images of the corresponding chart version
	2. envoy image of version listed in osm-arc/oss values.yaml
    3. grafana, grafana-image-renderer, prometheus, jaegertracing/all-in-one image of version listed in osm-arc/oss values.yaml
- [x] I have ensured that all the images mentioned in the previous step (aside from grafana-image-renderer) are available for both amd64 and arm64 architectures
- [x] I have updated the Helm chart:
    1. Updated the chart version, app version and dependency version in charts/osm-arc/Chart.yaml    
    2. Made applicable updates to the osm-arc values.yaml if any were made in the upstream OSM chart
    
    <!--
    In upstream, compare between the latest release and the previous release to check if anything has changed in the OSS values.yaml e.g: https://github.com/openservicemesh/osm/compare/v0.6.1...v0.7.0-rc.1
    Check for variable name changes, removed variables, variables that need to be overridden, etc. and make applicable changes in the osm-arc chart.    
    -->   
- [x] I have received 3 approvals from maintainers. 


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?