### PR TITLE
Bump osm-azure to latest version

### DIFF
--- a/.pipelines/templates/checkout-upstream-repo.yaml
+++ b/.pipelines/templates/checkout-upstream-repo.yaml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
   - name: ghUser
     type: string
     default: "osm-user"
@@ -8,7 +8,7 @@ parameters:
 
 steps:
   - bash: |
-      git clone https://${{ parameters.ghUser }}:$(AZURE_OSM_TOKEN)@github.com/${{ parameters.osmRepo }}
+      git clone https://$(AZURE_OSM_TOKEN)@github.com/${{ parameters.osmRepo }}
     displayName: Checkout $(upstream.repo)
     env:
       AZURE_OSM_TOKEN: $(AZURE_OSM_TOKEN)

--- a/.pipelines/upgrade-job/upgrade-templates.yaml
+++ b/.pipelines/upgrade-job/upgrade-templates.yaml
@@ -1,12 +1,12 @@
-steps:    
+steps:
   - template: ../templates/get-latest-tag.yaml
   - template: ../templates/add-arc-extension.yaml
-    parameters: 
-      imageTag: 1.2.3 # Temporarily hard-coding
+    parameters:
+      imageTag: $(LATEST_PUBLISHED_TAG)
   - script: |
       make test-e2e
     displayName: "Run osm-azure e2e tests on latest release chart"
-    env: 
-      EXTENSION_TAG: 1.2.3 # Temporarily hard-coding
+    env:
+      EXTENSION_TAG: $(LATEST_PUBLISHED_TAG)
       KUBECONFIG: $(System.DefaultWorkingDirectory)/kubeconfig.json
   - template: ../templates/update-arc-addon.yaml

--- a/charts/osm-arc/Chart.yaml
+++ b/charts/osm-arc/Chart.yaml
@@ -15,14 +15,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6
+version: 1.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.2.6
+appVersion: v1.2.9
 
 dependencies:
 - name: osm
-  version: "1.2.6"
+  version: "1.2.9"
   repository: "https://azure.github.io/osm"

--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -21,13 +21,13 @@ osm:
     enablePermissiveTrafficPolicy: true
     image:
       registry: mcr.microsoft.com/oss/openservicemesh
-      tag: v1.2.6
+      tag: v1.2.9
     enforceSingleMesh: true
     enableReconciler: false
     deployPrometheus: false
     deployJaeger: false
     webhookConfigNamePrefix: arc-osm-webhook
-    sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.26.7
+    sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.27.4
     osmController:
       podLabels: {
         app.kubernetes.io/component: osm-controller


### PR DESCRIPTION
<!--

Use the checklist below to ensure your release PR is complete before marking it ready for review.

-->

- [X] I have ensured that required images are available in MCR:
	1. osm-controller, osm-injector, osm-bootstrap, osm-crds and init images of the corresponding chart version
	2. envoy image of version listed in osm-arc/oss values.yaml
    3. grafana, grafana-image-renderer, prometheus, jaegertracing/all-in-one image of version listed in osm-arc/oss values.yaml
- [X] I have ensured that all the images mentioned in the previous step (aside from grafana-image-renderer) are available for both amd64 and arm64 architectures
- [X] I have updated the Helm chart:
    1. Updated the chart version, app version and dependency version in charts/osm-arc/Chart.yaml    
    2. Made applicable updates to the osm-arc values.yaml if any were made in the upstream OSM chart
    
    <!--
    In upstream, compare between the latest release and the previous release to check if anything has changed in the OSS values.yaml e.g: https://github.com/openservicemesh/osm/compare/v0.6.1...v0.7.0-rc.1
    Check for variable name changes, removed variables, variables that need to be overridden, etc. and make applicable changes in the osm-arc chart.    
    -->   
- [ ] I have received 3 approvals from maintainers. 
