### PR TITLE
Bump envoy version and put metrics behind a feature flag

### DIFF
--- a/charts/osm-arc/Chart.yaml
+++ b/charts/osm-arc/Chart.yaml
@@ -15,14 +15,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.9
+version: 1.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v1.2.9
+appVersion: v1.2.10
 
 dependencies:
 - name: osm
-  version: "1.2.9"
+  version: "1.2.10"
   repository: "https://azure.github.io/osm"

--- a/charts/osm-arc/templates/metrics-agent-deployment.yaml
+++ b/charts/osm-arc/templates/metrics-agent-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.Azure.enableMonitoring -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,9 +28,11 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}
       serviceAccount: {{ .Release.Name }}
+      nodeSelector:
+          kubernetes.io/os: linux
       containers:
         - name: mdm
-          image: linuxgeneva-microsoft.azurecr.io/genevamdm:2.2024.626.1539-d1a6e7-20240715t0935
+          image: linuxgeneva-microsoft.azurecr.io/genevamdm:2.2024.920.1834-1cce09-20240920t1950
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -86,7 +89,7 @@ spec:
             privileged: true
             {{- end }}
         - name: prom-mdm-converter
-          image: upstreamarc.azurecr.io/prom-mdm-converter:v1.0.0
+          image: upstreamarc.azurecr.io/prom-mdm-converter:v1.0.4
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -125,3 +128,4 @@ spec:
         - name: telegraf-conf
           configMap:
             name: osm-telegraf-config
+{{- end }}

--- a/charts/osm-arc/templates/metrics-config.yaml
+++ b/charts/osm-arc/templates/metrics-config.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.Azure.enableMonitoring -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -48,3 +49,4 @@ data:
         Content-Type = "application/x-protobuf"
         Content-Encoding = "snappy"
         X-Prometheus-Remote-Write-Version = "0.1.0"
+{{- end }}

--- a/charts/osm-arc/templates/metrics-rbac.yaml
+++ b/charts/osm-arc/templates/metrics-rbac.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.Azure.enableMonitoring -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -86,3 +87,4 @@ roleRef:
   kind: ClusterRole
   name: metrics-agent-cluster-role
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/osm-arc/values.yaml
+++ b/charts/osm-arc/values.yaml
@@ -10,6 +10,7 @@ Azure:
   Extension:
     Name: ""
     ResourceId: ""
+  enableMonitoring: false
 
 OpenServiceMesh:
   ignoreNamespaces: "kube-system azure-arc arc-osm-system"
@@ -27,7 +28,7 @@ osm:
     deployPrometheus: false
     deployJaeger: false
     webhookConfigNamePrefix: arc-osm-webhook
-    sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.27.5-hotfix.20240528
+    sidecarImage: mcr.microsoft.com/oss/envoyproxy/envoy:v1.28.7
     osmController:
       podLabels: {
         app.kubernetes.io/component: osm-controller

--- a/scripts/add-extension.sh
+++ b/scripts/add-extension.sh
@@ -23,7 +23,8 @@ if [[ -z "$EXTENSION_SETTINGS" ]]; then
       --name $EXTENSION_NAME \
       --release-namespace $RELEASE_NAMESPACE \
       --version $EXTENSION_TAG \
-      --auto-upgrade-minor-version false
+      --auto-upgrade-minor-version false \
+      --config Azure.enableMonitoring=true
 else
    az k8s-extension create \
       --cluster-name $CLUSTERNAME \
@@ -36,5 +37,6 @@ else
       --release-namespace $RELEASE_NAMESPACE \
       --version $EXTENSION_TAG \
       --auto-upgrade-minor-version false \
+      --config Azure.enableMonitoring=true \
       --configuration-settings-file $EXTENSION_SETTINGS
 fi


### PR DESCRIPTION
Bump envoy image to oldest supported minor version, update some other images in the metrics agent

Add new `Azure.enableMetrics` helm feature flag that toggles the metrics-related resources.
Defaults to false.



- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Networking             [ ]
- Metrics                [x]
- Security               [x]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?